### PR TITLE
(add/ci)release mode for docker (+ added dev-dockerfile for tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,5 @@ jobs:
       - run: make dependencies
       - run: make check
       - run: make build-dev
+      - run: make build
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: arkulturtest/naboo
+          images: bogdzn/naboo
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,6 @@ name: Docker
 on:
   push:
     branches:
-      - "dev"
-      - "canon"
-  pull_request:
-    branches:
       - "canon"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,12 @@ cleanup: ## Cleans the whole project, as if it was just cloned
 build: ## Build the Docker image for the OTP release
 	docker build \
 		--build-arg APP_VERSION=$(APP_VERSION)\
-		--build-arg APP_ENV=prod \
 		--rm --tag $(DOCKER_LOCAL_IMAGE) .
 
 .PHONY: build-dev
 build-dev: ## Build the Docker image for dev purposes
 	docker build \
-		--build-arg APP_VERSION=$(APP_VERSION)\
-		--build-arg APP_ENV=dev \
+		-f dockerfile.dev \
 		--rm --tag $(DOCKER_LOCAL_IMAGE)-dev .
 
 # Development targets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,11 @@ services:
   back-end:
     build:
       context: .
+      dockerfile: dockerfile.dev
     env_file:
       - .env.dev
     environment:
+      - MIX_ENV=dev
       - DATABASE_URL=postgres://anon:ChangeMe@database/naboo
       - POSTGRES_PORT=ChangeMe
       - POSTGRES_USER=anon

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,8 +1,10 @@
+# syntax=docker/dockerfile:1
+
 # Step 1 - hex dependencies
 #
 FROM hexpm/elixir:1.13.0-erlang-24.0.3-alpine-3.15.0 AS otp-dependencies
 
-ENV MIX_ENV=prod
+ENV MIX_ENV=dev
 
 WORKDIR /build
 
@@ -19,7 +21,7 @@ COPY priv priv
 # Install Erlang && hex dependencies
 RUN mix local.rebar --force && \
     mix local.hex --force && \
-    mix deps.get --only prod && \
+    mix deps.get && \
     mix deps.compile
 
 #
@@ -27,8 +29,7 @@ RUN mix local.rebar --force && \
 #
 FROM hexpm/elixir:1.13.0-erlang-24.0.3-alpine-3.15.0 AS otp-builder
 
-ARG APP_VERSION
-ENV MIX_ENV=prod
+ENV MIX_ENV=dev
 
 WORKDIR /build
 
@@ -56,46 +57,12 @@ COPY --from=otp-dependencies /build/_build _build
 COPY --from=otp-dependencies /build/mix.exs .
 COPY --from=otp-dependencies /build/mix.lock .
 
-# Generating release files
-RUN mix assets.deploy && \
-    mix compile && \
-    mix phx.gen.release && \
-    mix release
+# Copying files for test and CI
+COPY coveralls.json .
+COPY .credo.exs .
+COPY .sobelow-conf .
+COPY .formatter.exs .
 
-#
-# Step 3 - Copy binary to final container
-#
-FROM alpine:3.15.0 AS final
-
-ARG APP_VERSION
-
-ENV MIX_ENV=prod
-WORKDIR /opt/palpatine
-
-RUN apk update --no-cache && \
-    apk upgrade --no-cache && \
-    apk add --no-cache \
-        postgresql-client \
-        bash \
-        openssl \
-        libgcc \
-        libstdc++ \
-        ncurses-libs
-
-# Copy the OTP binary from the build step
-COPY --from=otp-builder /build/_build/prod/naboo-${APP_VERSION}.tar.gz .
-RUN tar -xvzf naboo-${APP_VERSION}.tar.gz && \
-    rm naboo-${APP_VERSION}.tar.gz
-
-
-# Copy Docker entrypoint
-COPY priv/docker-entrypoint.sh /usr/local/bin
-RUN chmod a+x /usr/local/bin/docker-entrypoint.sh
-
-# Create non-root user
-RUN adduser -D palpatine && \
-    chown -R palpatine: /opt/palpatine
-USER palpatine
+RUN mix assets.deploy
 
 ENTRYPOINT ["/build/priv/docker-entrypoint.sh"]
-CMD ["start"]

--- a/lib/api/router/urls.ex
+++ b/lib/api/router/urls.ex
@@ -40,7 +40,7 @@ defmodule NabooAPI.Router.Urls do
   def swagger_info do
     %{
       info: %{
-        version: "0.2",
+        version: "0.3",
         host: System.get_env("CANONICAL_URL"),
         title: "naboo"
       }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Naboo.Mixfile do
   def project do
     [
       app: :naboo,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.13",
       erlang: "~> 24.1",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/priv/docker-entrypoint.sh
+++ b/priv/docker-entrypoint.sh
@@ -5,9 +5,17 @@ set -euo pipefail
 # check if postgresql-client is installed
 which pg_isready >/dev/null || { echo "Postgres is not installed. Exiting." && exit 1 ; }
 
+# wait for postgresql service to boot
 while ! pg_isready -q -h "${POSTGRES_HOST}"; do
     echo "$(date) - waiting for database to start"
     sleep 1
 done
 
-mix ecto.setup && exec mix phx.server
+if [ "${MIX_ENV}" == "prod" ]; then
+    # Run the migration first using the custom release task and
+    # launch the OTP release and replace the caller as Process #1 in the container
+    /opt/palpatine/bin/naboo eval "Naboo.ReleaseTasks.migrate" && \
+        exec /opt/palpatine/bin/naboo "$@"
+else
+    mix ecto.setup && exec mix phx.server
+fi


### PR DESCRIPTION
- fixes #40 

- upgraded docker image to alpine 3.15
- remove docker build image when not a push on canon
- split docker-build into a full image for release mode and one named `naboo:x.x.x-dev` for developpers working on the project